### PR TITLE
Bugfix datetime.datetime.strptime (Python 2.7)

### DIFF
--- a/lib/oauth2client/client.py
+++ b/lib/oauth2client/client.py
@@ -620,6 +620,9 @@ class OAuth2Credentials(Credentials):
       try:
         data['token_expiry'] = datetime.datetime.strptime(
             data['token_expiry'], EXPIRY_FORMAT)
+      except TypeError:
+        data['token_expiry'] = datetime.datetime(*(time.strptime(
+            data['token_expiry'], EXPIRY_FORMAT)[0:6]))
       except ValueError:
         data['token_expiry'] = None
     retval = cls(


### PR DESCRIPTION
I have long time elaborated with a google calendar api using oauth2. All times I've gotten an odd behaviour as the oauth2client runs at first time but don't on second call. (got a TypeError).

The reason is a bad implementation of the strptime function that locks at a second call. This ist described at:

http://bugs.python.org/issue27400
http://forum.kodi.tv/showthread.php?tid=112916
http://forum.kodi.tv/showthread.php?tid=304736&highlight=strptime

oauthclient (client.py) use this function too. A workaround is to catch the TypeError with the code I suggest here. I confirm that this fix works for me now in my google calendar addon.

Thank you for attention.